### PR TITLE
use relative path for font

### DIFF
--- a/src/styles/base/_typography.scss
+++ b/src/styles/base/_typography.scss
@@ -6,7 +6,7 @@
 @font-face {
   font-family: 'Libre-Baskerville-Reg';
   font-display: fallback;
-  src: url('/fonts/LibreBaskerville-Regular.ttf') format('truetype');
+  src: url('fonts/LibreBaskerville-Regular.ttf') format('truetype');
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
Great project, thanks! Just wanted submit this PR to change the @font-face url to be a relative instead of absolute path. This causes a 404 when fetching the font in the production build if project is located outside of the root directory