### PR TITLE
Update .babelrc to not have to support dead browsers

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,7 +2,11 @@
   "presets": [
     ["@babel/preset-env", {
       "targets": {
-        "browsers": ["last 2 versions"]
+        "browsers": [
+            ">0.25%",
+            "not ie 11",
+            "not op_mini all"
+        ]
       }
     }]
   ]


### PR DESCRIPTION
as per: https://www.bram.us/2018/05/03/last-2-versions-considered-harmful/

Not a big deal. Mainly wanted to raise awareness and thought it might be something to consider. Thanks @michael-wolfenden for pointing this out.