### PR TITLE
Add preload/prefetch for css and fonts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8814,6 +8814,16 @@
       "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
       "dev": true
     },
+    "preload-webpack-plugin": {
+      "version": "3.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/preload-webpack-plugin/-/preload-webpack-plugin-3.0.0-beta.3.tgz",
+      "integrity": "sha512-pIRna/JagOd+ci64d84SfDH4bjKsM632OQ/4JIBk7Q8Kr6VH2X+7q5q3HrTilKpMzzO3ib9kC7rs1B0KXJTa6Q==",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.5.7",
+        "url-parse": "^1.4.3"
+      }
+    },
     "prepend-http": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "node-sass": "^4.11.0",
     "offline-plugin": "^5.0.6",
     "postcss-loader": "^3.0.0",
+    "preload-webpack-plugin": "^3.0.0-beta.3",
     "sass-loader": "^7.1.0",
     "script-ext-html-webpack-plugin": "^2.1.3",
     "style-loader": "^0.23.1",

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -4,6 +4,7 @@ const CleanWebpackPlugin = require('clean-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const ScriptExtHtmlWebpackPlugin = require("script-ext-html-webpack-plugin");
+const PreloadWebpackPlugin = require('preload-webpack-plugin');
 
 module.exports = {
   mode: 'development',
@@ -93,6 +94,16 @@ module.exports = {
       filename: '404.html',
       template: './src/404.html',
       inject: 'head'
+    }),
+    new PreloadWebpackPlugin({
+      rel: 'preload',
+      fileBlacklist: [/\.(js)$/],
+      include: 'allChunks'
+    }),
+    new PreloadWebpackPlugin({
+      rel: 'prefetch',
+      fileBlacklist: [/\.(jpe?g|png|gif|svg|js|css)$/],
+      include: 'allAssets'
     }),
     new ScriptExtHtmlWebpackPlugin({
       defaultAttribute: 'defer'

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -97,12 +97,10 @@ module.exports = {
     }),
     new PreloadWebpackPlugin({
       rel: 'preload',
-      fileBlacklist: [/\.(js)$/],
-      include: 'allChunks'
-    }),
-    new PreloadWebpackPlugin({
-      rel: 'prefetch',
-      fileBlacklist: [/\.(jpe?g|png|gif|svg|js|css)$/],
+      as(entry) {
+        if (/\.(woff|woff2|ttf|otf)$/.test(entry)) return 'font';
+      },
+      fileWhitelist: [/\.(woff|woff2|ttf|otf)$/],
       include: 'allAssets'
     }),
     new ScriptExtHtmlWebpackPlugin({


### PR DESCRIPTION
This will add preload for css files and prefetch for fonts, as described in #7.

Following pieces of code will do what you want, I added some comments for clarification.

```javascript
new PreloadWebpackPlugin({
      rel: 'preload', // Set to preload
      fileBlacklist: [/\.(js)$/], // Disable preload for .js files
      include: 'allChunks' // Use all chunks
    }),
```
```javascript
    new PreloadWebpackPlugin({
      rel: 'prefetch', // Set to prefetch
      fileBlacklist: [/\.(jpe?g|png|gif|svg|js|css)$/], // Disable for prefetch for these file extensions
      include: 'allAssets' // Use allAssets
    }),
```