### PR TITLE
Added Copy plugin and Write-file plugin for static files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2660,6 +2660,46 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
+    "copy-webpack-plugin": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-5.0.0.tgz",
+      "integrity": "sha512-iiDj+8nnZeW/i8vYJ3+ABSZkOefJnDYIGLojiZKKFDvf1wcEInABXH1+hN7axQMn04qvJxKjgVOee0e14XPtCg==",
+      "dev": true,
+      "requires": {
+        "cacache": "^11.3.1",
+        "find-cache-dir": "^2.0.0",
+        "globby": "^7.1.1",
+        "is-glob": "^4.0.0",
+        "loader-utils": "^1.1.0",
+        "minimatch": "^3.0.4",
+        "normalize-path": "^3.0.0",
+        "p-limit": "^2.1.0",
+        "serialize-javascript": "^1.4.0",
+        "webpack-log": "^2.0.0"
+      },
+      "dependencies": {
+        "globby": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
+          "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
+          "dev": true,
+          "requires": {
+            "array-union": "^1.0.1",
+            "dir-glob": "^2.0.0",
+            "glob": "^7.1.2",
+            "ignore": "^3.3.5",
+            "pify": "^3.0.0",
+            "slash": "^1.0.0"
+          }
+        },
+        "normalize-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+          "dev": true
+        }
+      }
+    },
     "core-js": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.3.tgz",
@@ -4305,6 +4345,12 @@
         "strip-outer": "^1.0.0",
         "trim-repeated": "^1.0.0"
       }
+    },
+    "filesize": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
+      "integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg==",
+      "dev": true
     },
     "fill-range": {
       "version": "4.0.0",
@@ -7264,6 +7310,12 @@
           "dev": true
         }
       }
+    },
+    "moment": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
+      "dev": true
     },
     "move-concurrently": {
       "version": "1.0.1",
@@ -11865,6 +11917,43 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "write-file-atomic": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.2.tgz",
+      "integrity": "sha512-s0b6vB3xIVRLWywa6X9TOMA7k9zio0TMOsl9ZnDkliA/cfJlpHXAscj0gbHVJiTdIuAYpIyqS5GW91fqm6gG5g==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "write-file-webpack-plugin": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/write-file-webpack-plugin/-/write-file-webpack-plugin-4.5.0.tgz",
+      "integrity": "sha512-k46VeERtaezbmjpDcMWATjKUWBrVe/ZEEm0cyvUm8FFP8A/r+dw5x3psRvkUOhqh9bqBLUlGYYbtr6luI+HeAg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.0",
+        "debug": "^3.1.0",
+        "filesize": "^3.6.1",
+        "lodash": "^4.17.5",
+        "mkdirp": "^0.5.1",
+        "moment": "^2.22.1",
+        "write-file-atomic": "^2.3.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
     },
     "xhr": {
       "version": "2.5.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
     "webpack": "^4.28.3",
     "webpack-cli": "^3.2.0",
     "webpack-dev-server": "^3.1.14",
-    "webpack-merge": "^4.2.1"
+    "webpack-merge": "^4.2.1",
+    "write-file-webpack-plugin": "^4.5.0",
+    "copy-webpack-plugin": "^5.0.0"
   },
   "dependencies": {
     "bulma": "^0.7.2",

--- a/src/robots.txt
+++ b/src/robots.txt
@@ -1,0 +1,1 @@
+User-agent: *

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -5,6 +5,8 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const ScriptExtHtmlWebpackPlugin = require('script-ext-html-webpack-plugin');
 const PreloadWebpackPlugin = require('preload-webpack-plugin');
+const CopyPlugin = require('copy-webpack-plugin');
+const WriteFilePlugin = require('write-file-webpack-plugin');
 
 module.exports = {
   mode: 'development',
@@ -83,6 +85,14 @@ module.exports = {
   },
   plugins: [
     new CleanWebpackPlugin(['dist']),
+    new WriteFilePlugin(),
+    new CopyPlugin([
+      { 
+        from: path.resolve(__dirname, 'src', 'robots.txt'),
+        to: path.resolve(__dirname, 'dist', 'robots.txt')
+      }
+    ]
+    ),
     new HtmlWebpackPlugin({
       title: 'tris-webpack-boilerplate',
       filename: 'index.html',


### PR DESCRIPTION
Hi,
I've added "copy-webpack-plugin" and "write-file-webpack-plugin" useful if you need to handle static files such as robots.txt. 

**copy-webpack-plugin**
[https://github.com/webpack-contrib/copy-webpack-plugin](https://github.com/webpack-contrib/copy-webpack-plugin)

**write-file-webpack-plugin**

> ℹ️ If you want `webpack-dev-server` to write files to the output directory during development, you can force it with the [`writeToDisk`](https://github.com/webpack/webpack-dev-middleware#writetodisk) option or the [`write-file-webpack-plugin`](https://github.com/gajus/write-file-webpack-plugin).

[https://github.com/gajus/write-file-webpack-plugin](https://github.com/gajus/write-file-webpack-plugin)

**How to**
```
plugins: [
  new WriteFilePlugin(),
  new CopyPlugin([
    { 
      from: path.resolve(__dirname, 'src', 'robots.txt'),
      to: path.resolve(__dirname, 'dist', 'robots.txt')
    },
    { 
      from: path.resolve(__dirname, 'src', 'myStaticFolder'),
      to: path.resolve(__dirname, 'dist', 'myStaticFolder')
    },
  ]
]