### PR TITLE
Optimizations and improvements

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,14 +1,20 @@
 const purgecss = require('@fullhuman/postcss-purgecss');
+const cssnano = require('cssnano');
 
-module.exports = {
-  plugins: [
-    require('autoprefixer'),
-    require('cssnano')({
-        preset: 'default',
-    }),
-    purgecss({
-      content: ['./**/*.html'],
-      keyframes: true
-    })
-  ]
+module.exports = (ctx) => {
+  return {
+    plugins: [
+      require('autoprefixer'),
+      ...ctx.options.env === 'production' ? [
+        cssnano({
+          preset: 'default',
+        }),
+        purgecss({
+          content: ['./**/*.html'],
+          keyframes: true,
+          defaultExtractor: content => content.match(/[A-z0-9-:/]+/g)
+        })
+      ] : []
+    ]
+  }
 }

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,8 +1,5 @@
-const path = require('path');
-
 const CleanWebpackPlugin = require('clean-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
-const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const ScriptExtHtmlWebpackPlugin = require('script-ext-html-webpack-plugin');
 const PreloadWebpackPlugin = require('preload-webpack-plugin');
 
@@ -49,30 +46,6 @@ module.exports = {
         }]
       },
       {
-        test: /\.(sa|sc|c)ss$/,
-        use: [
-          MiniCssExtractPlugin.loader,
-          {
-            loader: 'css-loader',
-            options: {
-              sourceMap: true
-            }
-          },
-          {
-            loader: 'postcss-loader',
-            options: {
-              sourceMap: true
-            }
-          },
-          {
-            loader: 'sass-loader',
-            options: {
-              sourceMap: true
-            }
-          }
-        ]
-      },
-      {
         test: /\.js$/,
         exclude: /(node_modules)/,
         use: {
@@ -108,10 +81,6 @@ module.exports = {
     }),
     new ScriptExtHtmlWebpackPlugin({
       defaultAttribute: 'defer'
-    }),
-    new MiniCssExtractPlugin({
-      filename: 'webpack-bundle.css',
-      chunkFilename: '[id].css'
     })
   ],
   externals: {

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -8,7 +8,10 @@ const PreloadWebpackPlugin = require('preload-webpack-plugin');
 
 module.exports = {
   mode: 'development',
-  entry: './src/index.js',
+  entry: {
+    main: './src/index.js',
+    vendor: './src/vendor.js'
+  },
   module: {
     rules: [{
         test: /\.txt$/,

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -15,15 +15,6 @@ module.exports = {
         use: 'raw-loader'
       },
       {
-        test: /\.html$/,
-        use: [{
-          loader: 'html-loader',
-          options: {
-            minimize: true
-          }
-        }]
-      },
-      {
         test: /\.(jpe?g|png|gif|svg)$/,
         use: [{
           loader: 'file-loader',

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -21,7 +21,7 @@ module.exports = {
           options: {
             name: '[name].[ext]',
             outputPath: 'images/',
-            publicPath: 'images/'
+            publicPath: '/images/'
           }
         }]
       },

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -115,9 +115,5 @@ module.exports = {
     $: 'jquery',
     jquery: 'jQuery',
     'window.$': 'jquery',
-  },
-  output: {
-    filename: 'webpack-bundle.js',
-    path: path.resolve(__dirname, 'dist')
   }
 };

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,11 +1,41 @@
+const path = require('path');
+
 const merge = require('webpack-merge');
 const common = require('./webpack.common.js');
 
 module.exports = merge(common, {
   mode: 'development',
   devtool: 'inline-source-map',
+  module: {
+    rules: [
+      {
+        test: /\.(sa|sc|c)ss$/,
+        use: [
+          'style-loader',
+          {
+            loader: 'css-loader',
+            options: {
+              sourceMap: true
+            }
+          },
+          {
+            loader: 'postcss-loader',
+            options: {
+              sourceMap: true
+            }
+          },
+          {
+            loader: 'sass-loader',
+            options: {
+              sourceMap: true
+            }
+          }
+        ]
+      },
+    ]
+  },
   output: {
-    filename: 'webpack-bundle.js',
+    filename: '[name].js',
     path: path.resolve(__dirname, 'dist')
   }
 });

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -9,6 +9,12 @@ module.exports = merge(common, {
   module: {
     rules: [
       {
+        test: /\.html$/,
+        use: [{
+          loader: 'html-loader'
+        }]
+      },
+      {
         test: /\.(sa|sc|c)ss$/,
         use: [
           'style-loader',

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -4,4 +4,8 @@ const common = require('./webpack.common.js');
 module.exports = merge(common, {
   mode: 'development',
   devtool: 'inline-source-map',
+  output: {
+    filename: 'webpack-bundle.js',
+    path: path.resolve(__dirname, 'dist')
+  }
 });

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -46,5 +46,9 @@ module.exports = merge(common, {
       }
     }),
     new OfflinePlugin()
-  ]
+  ],
+  output: {
+    filename: '[name].[contentHash].js',
+    path: path.resolve(__dirname, 'dist')
+  }
 });

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -20,6 +20,15 @@ module.exports = merge(common, {
   module: {
     rules: [
       {
+        test: /\.html$/,
+        use: [{
+          loader: 'html-loader',
+          options: {
+            minimize: true
+          }
+        }]
+      },
+      {
         test: /\.(sa|sc|c)ss$/,
         use: [
           MiniCssExtractPlugin.loader,

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -1,5 +1,9 @@
+const path = require('path');
+
 const merge = require('webpack-merge');
 const common = require('./webpack.common.js');
+
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
 const TerserPlugin = require('terser-webpack-plugin');
 const ImageminPlugin = require('imagemin-webpack-plugin').default;
@@ -13,6 +17,40 @@ const OfflinePlugin = require('offline-plugin');
 module.exports = merge(common, {
   mode: 'production',
   devtool: 'source-map',
+  module: {
+    rules: [
+      {
+        test: /\.(sa|sc|c)ss$/,
+        use: [
+          MiniCssExtractPlugin.loader,
+          {
+            loader: 'css-loader',
+            options: {
+              sourceMap: true
+            }
+          },
+          {
+            loader: 'postcss-loader',
+            options: {
+              sourceMap: true,
+              config: {
+                path: __dirname + '/postcss.config.js',
+                ctx: {
+                  env: 'production'
+                }
+              }
+            },
+          },
+          {
+            loader: 'sass-loader',
+            options: {
+              sourceMap: true
+            }
+          }
+        ]
+      },
+    ]
+  },
   optimization: {
     minimizer: [
       new TerserPlugin({
@@ -23,6 +61,10 @@ module.exports = merge(common, {
     ]
   },
   plugins: [
+    new MiniCssExtractPlugin({
+      filename: 'style.[contentHash].css',
+      chunkFilename: '[id].css'
+    }),
     new CompressionPlugin({
       test: /\.(html|css|js)(\?.*)?$/i // only compressed html/css/js, skips compressing sourcemaps etc
     }),


### PR DESCRIPTION
# **Decription**

I have added a few optimizations and improvements and fix for #22 issue.  

**1. Cache busting for final javascript bundle.**
currently, there is no cache busting in production mode. so sometimes when we deploy old files are cached by browser so those changes don't reflect when a user views page unless a user does hard refresh.

**2. Separate chunk for vendor files**
Code for third party libs does not change that often so keeping it in different chunk can be helpful as the content of vendor chunk won't be change so often (e.g bootstrap js, jquery)  so that chunk can be loaded from cache.

**3. CSS purge, minification, and extraction.**
When we are working in dev mode there is no need for CSS extraction, minification and purging unused CSS.

**4. HTML minification**
When we are working in dev mode there is no need of minification of html so we can remove that extra step in dev mode.

**5. Fixed public path for images**
If user decides to change output directory for some of html files injected path of images wont load.